### PR TITLE
Job DSL Examples for JTE

### DIFF
--- a/job-dsl-examples/README.rst
+++ b/job-dsl-examples/README.rst
@@ -2,13 +2,13 @@ Job DSL Examples for Utilizing the Jenkins Templating Engine
 =========================
 
 What are Job DSL Scripts?
-*****************
+*************************
 Job DSL scripts can be used to create and configure Jenkins jobs programatically. These scripts are used through the `Job DSL Plugin
-found here <https://github.com/jenkinsci/job-dsl-plugin>`_
+<https://github.com/jenkinsci/job-dsl-plugin>`_
 
 
 Github Organization Job DSL Script (github_organization.groovy)
-^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This script will create and configure a Github Organization job in Jenkins by doing the following:
 
 - Under "Projects"

--- a/job-dsl-examples/README.rst
+++ b/job-dsl-examples/README.rst
@@ -1,8 +1,8 @@
 Job DSL Examples for Utilizing the Jenkins Templating Engine
-=========================
+============================================================
 
 What are Job DSL Scripts?
-^^^^^^^^^^^^^^^^^^^^^^^^^
+*************************
 Job DSL scripts can be used to create and configure Jenkins jobs programatically. These scripts are used through the `Job DSL Plugin
 <https://github.com/jenkinsci/job-dsl-plugin>`_
 

--- a/job-dsl-examples/README.rst
+++ b/job-dsl-examples/README.rst
@@ -1,0 +1,37 @@
+Job DSL Examples for Utilizing the Jenkins Templating Engine
+=========================
+
+What are Job DSL Scripts?
+*****************
+Job DSL scripts can be used to create and configure Jenkins jobs programatically. These scripts are used through the `Job DSL Plugin
+found here <https://github.com/jenkinsci/job-dsl-plugin>`_
+
+
+Github Organization Job DSL Script (github_organization.groovy)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+This script will create and configure a Github Organization job in Jenkins by doing the following:
+
+- Under "Projects"
+
+  - Specifying the Github Organization
+  - Which Github Credentials to use
+  - Behaviors
+  - Specifying the Jenkins Templating Engine as a project recognizer
+
+- Under "Solutions Delivery Platform"
+
+  - Pointing the Pipeline Configuration Source to the correct Github Repository
+  - Configuring the base directory of the configuration
+  - Pointing the Library Source to the correct Github Repository
+
+In order for the script to be configured properly for your own use, the following environment variables need to be available for
+the script to use:
+
+- TENANT_GITHUB_ORG
+- TENANT_GITHUB_CREDS_ID
+- TENANT_GITHUB_API_URL
+- TENANT_GITHUB_CONFIG_URL
+- TENANT_GITHUB_LIBRARY_URL
+- BASE_DIRECTORY
+
+It is up to you to determine how these environment variables are set.

--- a/job-dsl-examples/README.rst
+++ b/job-dsl-examples/README.rst
@@ -2,7 +2,7 @@ Job DSL Examples for Utilizing the Jenkins Templating Engine
 =========================
 
 What are Job DSL Scripts?
-*************************
+^^^^^^^^^^^^^^^^^^^^^^^^^
 Job DSL scripts can be used to create and configure Jenkins jobs programatically. These scripts are used through the `Job DSL Plugin
 <https://github.com/jenkinsci/job-dsl-plugin>`_
 

--- a/job-dsl-examples/github_organization.groovy
+++ b/job-dsl-examples/github_organization.groovy
@@ -1,0 +1,62 @@
+githubOrg = System.getenv("TENANT_GITHUB_ORG")
+credId = System.getenv("TENANT_GITHUB_CREDS_ID")
+apiUri = System.getenv("TENANT_GITHUB_API_URL")
+orgPipelineRepo = System.getenv("TENANT_GITHUB_CONFIG_URL")
+libraryRepo = System.getenv("TENANT_GITHUB_LIBRARY_URL")
+baseDirectory = System.getenv("BASE_DIRECTORY")
+
+organizationFolder githubOrg, {
+  configure{
+    it / 'properties' << 'org.boozallen.plugins.jte.config.TemplateConfigFolderProperty' {
+        tier {
+            baseDir(baseDirectory)
+            scm (class: 'hudson.plugins.git.GitSCM'){
+                configVersion 2
+                userRemoteConfigs{
+                  'hudson.plugins.git.UserRemoteConfig' {
+                    url orgPipelineRepo
+                    credentialsId credId
+                  }
+                }
+                branches{
+                  'hudson.plugins.git.BranchSpec'{
+                    name "*/master"
+                  }
+                }
+      		}
+            librarySources{
+                'org.boozallen.plugins.jte.config.TemplateLibrarySource'{
+                    scm (class: 'hudson.plugins.git.GitSCM'){
+                        configVersion 2
+                        userRemoteConfigs{
+                          'hudson.plugins.git.UserRemoteConfig' {
+                            url libraryRepo
+                            credentialsId credId
+                          }
+                        }
+                        branches{
+                          'hudson.plugins.git.BranchSpec'{
+                            name "*/master"
+                          }
+                        }
+      				      }
+                }
+            }
+        }
+    }
+    it / 'navigators' << 'org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator'{
+      repoOwner githubOrg
+      scanCredentialsId credId
+      checkoutCredentialsId 'SAME'
+      apiUri apiUri
+      buildOriginBranch true
+      buildOriginBranchWithPR false
+      buildOriginPRMerge true
+      buildOriginPRHead false
+      buildForkPRMerge false
+      buildForkPRHead false
+    }
+    it / 'projectFactories' << 'org.boozallen.plugins.jte.job.TemplateMultiBranchProjectFactory' {
+    }
+  }
+}


### PR DESCRIPTION
Added a job DSL script for creating a organization jenkins job. Intended use is for people to add different job dsl scripts into this folder that they have created utilizing the JTE plugin. 