### PR TITLE
get rid of heavy checkout and build scm file system differently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/_build
 .project
 .classpath
 .gradle
+.idea


### PR DESCRIPTION
Getting rid of support for HeavyWeight checkout as it unnecessarily complicates things and choosing to support SCM options that are supported by the new (as of like.. 2017) Jenkins SCM API: https://plugins.jenkins.io/scm-api

There was an issue (cause of which is unknown to me) with building the SCMFileSystem from the GitSCM instance when the branch name had a / in the name. 

Building the SCMFileSystem from the SCMSource and SCMHead resolved the issue and also worked for other use cases. 

This fixes the issue for multibranch jobs, but would need more testing for a regular pipeline job. 

for now - it's working better than what's currently in master so i would be comfortable merging it in. 