### PR TITLE
Unit Test StepWrapper + allow arbitrary step methods

### DIFF
--- a/docs/pages/Library_Development/index.rst
+++ b/docs/pages/Library_Development/index.rst
@@ -44,7 +44,7 @@ For example, to create a ``build`` step, add a ``build.groovy`` file:
     example_library/ 
         build.groovy 
 
-Writing a step is done by defining a ``call`` method within the groovy step file created. This 
+In most cases, writing a step is done by defining a ``call`` method within the groovy step file created. This 
 ``call`` method can take input arguments and return objects.  Within the step you can execute any 
 old regular Jenkins pipeline code, including invoking other steps defined by loaded libraries. 
 
@@ -59,6 +59,10 @@ could be:
         }
     }
 
+.. note:: 
+
+    Steps, like regular global variables in Jenkins Shared Libraries, can define methods other than call. 
+    See an example :ref:`here <noncall_methods>` 
 
 
 ================

--- a/docs/pages/Library_Development/noncall_methods.rst
+++ b/docs/pages/Library_Development/noncall_methods.rst
@@ -4,4 +4,24 @@
 Defining Non-Call Methods in Library Steps
 ------------------------------------------
 
-In 
+It is sometimes advantageous to define more steps than just the call method.  
+
+Within the context of creating templates, this pattern comes up when defining internal methods 
+used by library steps as opposed to being invoked directly by a template. 
+
+For example: 
+
+.. code-block:: groovy
+   :caption: test_step.groovy
+
+    def printMessage(String message){
+        println "the message is ${message}" 
+    }
+
+creates a step ``test_step`` that can be invoked via: 
+
+.. code-block:: groovy
+
+    test_step.printMessage("example!")
+
+    

--- a/docs/pages/Library_Development/noncall_methods.rst
+++ b/docs/pages/Library_Development/noncall_methods.rst
@@ -1,0 +1,7 @@
+.. _noncall_methods: 
+
+------------------------------------------
+Defining Non-Call Methods in Library Steps
+------------------------------------------
+
+In 

--- a/src/main/groovy/org/boozallen/plugins/jte/binding/LibraryLoader.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/binding/LibraryLoader.groovy
@@ -61,7 +61,12 @@ import jenkins.model.Jenkins
                                 String stepName = step.getName() - ".groovy" 
                                 Script stepImpl = Utils.parseScript(step.contentAsString(), script.getBinding())
                                 stepImpl.metaClass."get${StepWrapper.libraryConfigVariable.capitalize()}" << { return libConfig }
-                                StepWrapper sw = new StepWrapper(script, stepImpl, stepName, libName) 
+                                StepWrapper sw = new StepWrapper(
+                                    script: script, 
+                                    impl: stepImpl, 
+                                    name: stepName, 
+                                    library: libName
+                                ) 
                                 script.getBinding().setVariable(stepName, sw) 
                             }
                             foundLibrary = true 
@@ -107,7 +112,12 @@ import jenkins.model.Jenkins
                 Script defaultStepImpl = Utils.parseScript(defaultStepImplString, script.getBinding())
                 //stepConfig["step"] = stepName 
                 defaultStepImpl.metaClass."get${StepWrapper.libraryConfigVariable.capitalize()}" << { return stepConfig }
-                StepWrapper sw = new StepWrapper(script, defaultStepImpl, stepName, "Default Step Implementation") 
+                StepWrapper sw = new StepWrapper(
+                    script: script, 
+                    impl: defaultStepImpl, 
+                    name: stepName, 
+                    library: "Default Step Implementation"
+                ) 
                 script.getBinding().setVariable(stepName, sw)
             } else {
                 /*

--- a/src/main/groovy/org/boozallen/plugins/jte/binding/StepWrapper.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/binding/StepWrapper.groovy
@@ -33,36 +33,38 @@ class StepWrapper extends TemplatePrimitive{
     private CpsScript script
     private String name
     private String library 
-    
-    StepWrapper(){}
 
-    
-    StepWrapper(CpsScript script, Object impl, String name, String library){ 
-        this.script = script
-        
-        if(!InvokerHelper.getMetaClass(impl).respondsTo(impl, "call")){
-            throw new TemplateException ("StepWrapper impl object must respond to 'call'. Was passed ${impl.getClass()}")
-        }
-
-        this.impl = impl
-        this.name = name
-        this.library = library 
+    /*
+        need a call method defined on method missing so that 
+        CpsScript recognizes the StepWrapper as something it 
+        should execute. 
+    */
+    def call(Object... args){
+        return invoke("call", args) 
     }
 
-    @Whitelisted
-    def call(Object... args){
-        /*
-            any invocation of pipeline code from a plugin class of more than one
-            executable script or closure requires to be parsed through the execution
-            shell or the method returns prematurely after the first execution
-        */
-        String invoke =  Jenkins.instance
-                                .pluginManager
-                                .uberClassLoader
-                                .loadClass("org.boozallen.plugins.jte.binding.StepWrapper")
-                                .getResource("StepWrapperImpl.groovy")
-                                .text
-        return Utils.parseScript(invoke, script.getBinding())(name, library, script, impl, args)
+    def methodMissing(String methodName, args){
+        return invoke(methodName, args)     
+    }
+
+    def invoke(String methodName, Object... args){
+        if(InvokerHelper.getMetaClass(impl).respondsTo(impl, methodName, args)){
+            /*
+                any invocation of pipeline code from a plugin class of more than one
+                executable script or closure requires to be parsed through the execution
+                shell or the method returns prematurely after the first execution
+            */
+            String invoke =  Jenkins.instance
+                                    .pluginManager
+                                    .uberClassLoader
+                                    .loadClass("org.boozallen.plugins.jte.binding.StepWrapper")
+                                    .getResource("StepWrapperImpl.groovy")
+                                    .text
+            Script step = Utils.parseScript(invoke, script.getBinding())
+            return step(name, library, script, impl, methodName, args)
+        }else{
+            throw new TemplateException("Step ${name} from the library ${library} does not have the method ${methodName}(${args.collect{ it.getClass().simpleName }.join(", ")})")
+        }
     }
 
     void throwPreLockException(){

--- a/src/main/groovy/org/boozallen/plugins/jte/binding/StepWrapper.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/binding/StepWrapper.groovy
@@ -44,6 +44,7 @@ class StepWrapper extends TemplatePrimitive{
         CpsScript recognizes the StepWrapper as something it 
         should execute in the binding. 
     */
+    @Whitelisted
     def call(Object... args){
         return invoke("call", args) 
     }
@@ -53,6 +54,7 @@ class StepWrapper extends TemplatePrimitive{
         first retrieve the StepWrapper and then attempt to invoke a 
         method on it. 
     */
+    @Whitelisted
     def methodMissing(String methodName, args){
         return invoke(methodName, args)     
     }
@@ -61,6 +63,7 @@ class StepWrapper extends TemplatePrimitive{
         pass method invocations on the wrapper to the underlying
         step implementation script. 
     */
+    @Whitelisted
     def invoke(String methodName, Object... args){
         if(InvokerHelper.getMetaClass(impl).respondsTo(impl, methodName, args)){
             /*

--- a/src/main/resources/org/boozallen/plugins/jte/binding/StepWrapperImpl.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/binding/StepWrapperImpl.groovy
@@ -8,7 +8,7 @@ import org.jenkinsci.plugins.workflow.cps.CpsScript
 import org.codehaus.groovy.runtime.InvokerHelper
 import org.codehaus.groovy.runtime.InvokerInvocationException
 
-def call(String name, String library, CpsScript script, Object impl, Object... args){
+def call(String name, String library, CpsScript script, Object impl, String methodName, Object... args){
     def result
     def context = [
         step: name, 
@@ -17,8 +17,8 @@ def call(String name, String library, CpsScript script, Object impl, Object... a
     ]
     try{
         Hooks.invoke(BeforeStep, script.getBinding(), context)
-        Utils.getLogger().println "[JTE][Step - ${library}/${name}]" 
-        result = InvokerHelper.getMetaClass(impl).invokeMethod(impl, "call", args)
+        Utils.getLogger().println "[JTE][Step - ${library}/${name}.${methodName}(${args.collect{ it.getClass().simpleName }.join(", ")})]" 
+        result = InvokerHelper.getMetaClass(impl).invokeMethod(impl, methodName, args)
     } catch (Exception x) {
         script.currentBuild.result = "Failure"
         throw new InvokerInvocationException(x)

--- a/src/test/groovy/org/boozallen/plugins/jte/binding/StepWrapperSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/binding/StepWrapperSpec.groovy
@@ -1,0 +1,356 @@
+/*
+   Copyright 2018 Booz Allen Hamilton
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package org.boozallen.plugins.jte.binding
+
+
+import org.boozallen.plugins.jte.Utils
+import org.boozallen.plugins.jte.config.TemplateConfigObject
+import org.boozallen.plugins.jte.config.TemplateGlobalConfig
+import org.boozallen.plugins.jte.config.TemplateLibrarySource
+import org.boozallen.plugins.jte.config.GovernanceTier
+import spock.lang.* 
+import org.junit.ClassRule
+import org.junit.Rule
+import org.jvnet.hudson.test.JenkinsRule
+import org.jvnet.hudson.test.BuildWatcher
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import com.cloudbees.hudson.plugins.folder.Folder
+import jenkins.plugins.git.GitSampleRepoRule
+import hudson.plugins.git.GitSCM
+import hudson.plugins.git.BranchSpec
+import hudson.plugins.git.extensions.GitSCMExtension
+import hudson.plugins.git.SubmoduleConfig
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
+import hudson.model.Result;
+
+class StepWrapperSpec extends Specification{
+
+    @Rule JenkinsRule jenkins = new JenkinsRule()
+    @Shared @ClassRule BuildWatcher bw = new BuildWatcher()
+    @Rule GitSampleRepoRule librarySource = new GitSampleRepoRule()
+    GovernanceTier tier
+
+    /*
+        initial pipeline script that'll load the 
+        test library and initialize the binding. 
+    */
+    String pipelineInit = """
+        import org.boozallen.plugins.jte.binding.LibraryLoader
+        import org.boozallen.plugins.jte.binding.TemplateBinding
+        import org.boozallen.plugins.jte.config.TemplateConfigObject 
+
+        setBinding(new TemplateBinding())
+        pipelineConfig = new TemplateConfigObject(config: [
+            libraries: [
+                test: [
+                    random: "random",
+                    eleven: 11 
+                ]
+            ]
+        ])
+
+        LibraryLoader.doInject(pipelineConfig, this)
+    """
+
+    def setup(){
+        /*
+            create library "test" with step "test_step" 
+        */
+        librarySource.init()
+      
+        GitSCM scm = new GitSCM(
+            GitSCM.createRepoList(librarySource.toString(), null), 
+            Collections.singletonList(new BranchSpec("*/master")), 
+            false, 
+            Collections.<SubmoduleConfig>emptyList(), 
+            null, 
+            null, 
+            Collections.<GitSCMExtension>emptyList()
+        )
+
+        /*
+            create global governance tier registering library source 
+        */
+        List<TemplateLibrarySource> librarySources = [ new TemplateLibrarySource(scm: scm) ]
+        tier = new GovernanceTier(null, "", librarySources)            
+        TemplateGlobalConfig global = TemplateGlobalConfig.get() 
+        global.setTier(tier) 
+
+    }
+
+    void createStep(String name, String impl){
+        librarySource.write("test/${name}.groovy", impl)
+        librarySource.git("add", "*")
+        librarySource.git("commit", "--message=init")
+    }
+
+    def "steps invocable via call shorthand with no params"(){
+        when: 
+            createStep("test_step", """
+            void call(){
+                println "test" 
+            }
+            """)
+            WorkflowJob job = jenkins.createProject(WorkflowJob, "job"); 
+            job.setDefinition(new CpsFlowDefinition(""" ${pipelineInit}
+                test_step()
+            """, false))
+        then: 
+            jenkins.assertLogContains("test", jenkins.buildAndAssertSuccess(job)) 
+    }
+
+    def "steps invocable via call shorthand with one param"(){
+        when: 
+            createStep("test_step", """
+            void call(String msg){
+                println "msg -> \${msg}" 
+            }
+            """)
+            WorkflowJob job = jenkins.createProject(WorkflowJob, "job"); 
+            job.setDefinition(new CpsFlowDefinition(""" ${pipelineInit}
+                test_step("message")
+            """, false))
+        then: 
+            jenkins.assertLogContains("msg -> message", jenkins.buildAndAssertSuccess(job)) 
+    }
+
+    def "steps invocable via call shorthand with more than one param"(){
+        when: 
+            createStep("test_step", """
+            void call(String msg, Integer i){
+                println "msg -> \${msg} + \${i}" 
+            }
+            """)
+            WorkflowJob job = jenkins.createProject(WorkflowJob, "job"); 
+            job.setDefinition(new CpsFlowDefinition(""" ${pipelineInit}
+                test_step("message", 3)
+            """, false))
+        then: 
+            jenkins.assertLogContains("msg -> message + 3", jenkins.buildAndAssertSuccess(job)) 
+    }
+
+    def "steps can invoke non-call methods with no params"(){
+        when: 
+            createStep("test_step", """
+            void other(){
+                println "other" 
+            }
+            """)
+            WorkflowJob job = jenkins.createProject(WorkflowJob, "job"); 
+            job.setDefinition(new CpsFlowDefinition(""" ${pipelineInit}
+                test_step.other()
+            """, false))
+        then: 
+            jenkins.assertLogContains("other", jenkins.buildAndAssertSuccess(job)) 
+    }
+
+    def "steps can invoke non-call methods with 1 param"(){
+        when: 
+            createStep("test_step", """
+            void other(String msg){
+                println "message is \${msg}" 
+            }
+            """)
+            WorkflowJob job = jenkins.createProject(WorkflowJob, "job"); 
+            job.setDefinition(new CpsFlowDefinition(""" ${pipelineInit}
+                test_step.other("example")
+            """, false))
+        then: 
+            jenkins.assertLogContains("message is example", jenkins.buildAndAssertSuccess(job)) 
+    }
+
+    def "steps can invoke non-call methods with more than 1 param"(){
+        when: 
+            createStep("test_step", """
+            void other(String msg, String msg2){
+                println "message is \${msg} + \${msg2}" 
+            }
+            """)
+            WorkflowJob job = jenkins.createProject(WorkflowJob, "job"); 
+            job.setDefinition(new CpsFlowDefinition(""" ${pipelineInit}
+                test_step.other("example1", "example2")
+            """, false))
+        then: 
+            jenkins.assertLogContains("message is example1 + example2", jenkins.buildAndAssertSuccess(job)) 
+    }
+
+    def "steps can access configuration via config variable"(){
+        when: 
+            createStep("test_step", """
+            void call(){
+                assert ${StepWrapper.libraryConfigVariable} == [ 
+                    random: "random", 
+                    eleven: 11
+                ] 
+                println "${StepWrapper.libraryConfigVariable}.random -> '\${${StepWrapper.libraryConfigVariable}.random}'"
+            }
+            """)
+            WorkflowJob job = jenkins.createProject(WorkflowJob, "job"); 
+            job.setDefinition(new CpsFlowDefinition(""" ${pipelineInit}
+                test_step()
+            """, false))
+        then: 
+            jenkins.assertLogContains("config.random -> 'random'", jenkins.buildAndAssertSuccess(job))
+    }
+
+    def "steps can invoke pipeline steps directly"(){
+        when: 
+        createStep("test_step", """
+        void call(){
+            node{
+                sh "echo hello"
+            }
+        }
+        """)
+        WorkflowJob job = jenkins.createProject(WorkflowJob, "job"); 
+        job.setDefinition(new CpsFlowDefinition(""" ${pipelineInit}
+            test_step()
+        """, false))
+        then: 
+            jenkins.assertLogContains("hello", jenkins.buildAndAssertSuccess(job))
+    }
+
+    def "return step return result through StepWrapper"(){
+        when: 
+            createStep("test_step", """
+            def call(){
+                return "example"
+            }
+            """)
+            WorkflowJob job = jenkins.createProject(WorkflowJob, "job"); 
+            job.setDefinition(new CpsFlowDefinition(""" ${pipelineInit}
+                def r = test_step()
+                println "return is \${r}"
+            """, false))
+        then: 
+            jenkins.assertLogContains("return is example", jenkins.buildAndAssertSuccess(job))
+    }
+
+    def "step method not found throws TemplateException"(){
+        when: 
+            createStep("test_step", "def call(){ println 'blah' }")
+            WorkflowJob job = jenkins.createProject(WorkflowJob, "job"); 
+            job.setDefinition(new CpsFlowDefinition(""" ${pipelineInit}
+                test_step.nonexistent() 
+            """, false))
+            def build = job.scheduleBuild2(0).get() 
+        then: 
+            jenkins.assertBuildStatus(Result.FAILURE, build)
+            jenkins.assertLogContains("TemplateException: Step test_step from the library test does not have the method nonexistent()", build)
+    }
+
+    def "step override during initialization throws exception"(){
+        when: 
+            TemplateBinding binding = new TemplateBinding()
+            StepWrapper s = new StepWrapper(name: "test", library: "testlib")
+            binding.setVariable("test", s) 
+            binding.setVariable("test", "whatever")
+                
+        then: 
+            TemplateException ex = thrown() 
+            ex.message == "Library Step Collision. The step test already defined via the testlib library."
+    }
+
+    def "step override post initialization throws exception"(){
+        when: 
+            TemplateBinding binding = new TemplateBinding()
+            StepWrapper s = new StepWrapper(name: "test", library: "testlib")
+            binding.setVariable("test", s) 
+            binding.lock()
+            binding.setVariable("test", "whatever")
+                
+        then: 
+            TemplateException ex = thrown() 
+            ex.message == "Library Step Collision. The variable test is reserved as a library step via the testlib library."
+    }
+
+    def "@BeforeStep executes before step"(){
+        when: 
+            createStep("test_step", "def call(){ println 'testing' }")
+            createStep("test_step2", """
+            @BeforeStep
+            def call(Map Context){ 
+                println "before!" 
+            }
+            """)
+            WorkflowJob job = jenkins.createProject(WorkflowJob, "job"); 
+            job.setDefinition(new CpsFlowDefinition(""" ${pipelineInit}
+                test_step()
+            """, false))
+            def build = job.scheduleBuild2(0).get() 
+            def bN, sN 
+            jenkins.getLog(build).eachLine{ line, N -> 
+                if (line.contains("before!")) bN = N 
+                if (line.contains("testing")) sN = N 
+            }
+        then: 
+            jenkins.assertBuildStatusSuccess(build)
+            jenkins.assertLogContains("before!", build)
+            jenkins.assertLogContains("testing", build)
+            assert bN < sN 
+    } 
+
+    def "@AfterStep executes after step"(){
+        when: 
+            createStep("test_step", "def call(){ println 'testing' }")
+            createStep("test_step2", """
+            @AfterStep
+            def call(Map Context){ 
+                println "after!" 
+            }
+            """)
+            WorkflowJob job = jenkins.createProject(WorkflowJob, "job"); 
+            job.setDefinition(new CpsFlowDefinition(""" ${pipelineInit}
+                test_step()
+            """, false))
+            def build = job.scheduleBuild2(0).get() 
+            def aN, sN 
+            jenkins.getLog(build).eachLine{ line, N -> 
+                if (line.contains("testing")) sN = N 
+                if (line.contains("after!")) aN = N
+            }
+        then: 
+            jenkins.assertBuildStatusSuccess(build)
+            jenkins.assertLogContains("testing", build)
+            jenkins.assertLogContains("after!", build)
+            assert sN < aN 
+    }
+
+    def "@Notify executes after step"(){
+        when: 
+            createStep("test_step", "def call(){ println 'testing' }")
+            createStep("test_step2", """
+            @Notify
+            def call(Map Context){ 
+                println "notify!" 
+            }
+            """)
+            WorkflowJob job = jenkins.createProject(WorkflowJob, "job"); 
+            job.setDefinition(new CpsFlowDefinition(""" ${pipelineInit}
+                test_step()
+            """, false))
+            def build = job.scheduleBuild2(0).get() 
+            def nN, sN 
+            jenkins.getLog(build).eachLine{ line, N -> 
+                if (line.contains("testing")) sN = N 
+                if (line.contains("notify!")) nN = N
+            }
+        then: 
+            jenkins.assertBuildStatusSuccess(build)
+            jenkins.assertLogContains("testing", build)
+            jenkins.assertLogContains("notify!", build)
+            assert sN < nN 
+    }
+
+}

--- a/src/test/groovy/org/boozallen/plugins/jte/binding/StepWrapperSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/binding/StepWrapperSpec.groovy
@@ -13,8 +13,6 @@
 
 package org.boozallen.plugins.jte.binding
 
-
-import org.boozallen.plugins.jte.Utils
 import org.boozallen.plugins.jte.config.TemplateConfigObject
 import org.boozallen.plugins.jte.config.TemplateGlobalConfig
 import org.boozallen.plugins.jte.config.TemplateLibrarySource
@@ -25,7 +23,6 @@ import org.junit.Rule
 import org.jvnet.hudson.test.JenkinsRule
 import org.jvnet.hudson.test.BuildWatcher
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
-import com.cloudbees.hudson.plugins.folder.Folder
 import jenkins.plugins.git.GitSampleRepoRule
 import hudson.plugins.git.GitSCM
 import hudson.plugins.git.BranchSpec


### PR DESCRIPTION
# PR Details

- adds unit testing to the StepWrapper primitive
- refactors StepWrapper to use ``methodMissing()`` to allow arbitrary additional methods beyond call to be defined and invoke via ``<step_name>.<method_name>()``

## How Has This Been Tested

**unit tests**
``gradle clean jacocoTestReport`` 

**integration tests**
ran this pipeline script in jenkins to validate: 
```
import org.boozallen.plugins.jte.Utils
import org.boozallen.plugins.jte.binding.*


setBinding(new TemplateBinding())

test_step = new StepWrapper(
    script: this,
    impl: Utils.parseScript("""
    def call(){
        println "test step" 
    }
    void blah(String msg){
        println "print a message: \${msg}"
    }
    """, getBinding()),
    name: "test_step",
    library: "testing"
)

test_step.blah("example")
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Unit Testing
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [] I have updated the Change Log appropriately. 