### PR TITLE
adding syntax checking to config dsl

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
+2019-05-20 Steven Terrana
+  * Add syntax checking to configuration file DSL parsing
 
+2019-05-15
+  * fix regression where libraries are not loaded with the most recent code. 
+  
 2019-04-12 Carlos OKieffe
   * adding library sources base directory
 
@@ -12,6 +17,3 @@
   * Internal refactoring to simplify library loading
   * Add unit testing for Steps, Library Sources, and the Library Loader 
   * Adds helper methods hasStep() and getStep() to the TemplateBinding
-
-2019-05-15
-  * fix regression where libraries are not loaded with the most recent code. 

--- a/src/test/groovy/org/boozallen/plugins/jte/config/TemplateConfigDslSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/config/TemplateConfigDslSpec.groovy
@@ -234,4 +234,27 @@ class TemplateConfigDslSpec extends Specification {
             configObject.override == [] as Set
     }
 
+    def "syntax validation for unquoted values"(){
+        setup: 
+            String config = "a = b" 
+        when: 
+            TemplateConfigObject configObject = TemplateConfigDsl.parse(config)
+        then: 
+            TemplateConfigException ex = thrown()
+            ex.message.contains('did you mean: a = "b"')
+    }
+
+    def "syntax validation for setting configs equal to blocks"(){
+        setup: 
+            String config = """
+            a = b{
+                field = true 
+            }
+            """
+        when: 
+            TemplateConfigObject configObject = TemplateConfigDsl.parse(config)
+        then: 
+            thrown(TemplateConfigException)
+    }
+
 }


### PR DESCRIPTION
# PR Details

fixing CLOUDPLAT-558 

adding some syntax validation to configuration files so instances like
```
a = b
```

throws exception instead of creating a configuration of:
```
[
  a: null,
  b: [:] 
]
```

exception:
```
org.boozallen.plugins.jte.config.TemplateConfigException: Template Configuration File Syntax Error: 
line containing: a = b 
Referencing other configs is not permitted, or you forgot to quote the value.
did you mean: a = "b"
```
## Description

added an enum to the TemplateConfigBuilder class that ``propertyMissing`` and ``methodMissing`` return.  If this is the value passed to ``setProperty`` then a syntax error occurred.

 
## How Has This Been Tested

manual testing within Jenkins and unit tests added for syntax checks

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have updated the Change Log appropriately. 