### PR TITLE
New repositories use "main" as default branch name

### DIFF
--- a/src/test/groovy/org/boozallen/plugins/jte/config/GovernanceTierSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/config/GovernanceTierSpec.groovy
@@ -57,7 +57,7 @@ class GovernanceTierSpec extends Specification{
         // create common SCM  
         GitSCM scm = new GitSCM(
             GitSCM.createRepoList(sampleRepo.toString(), null), 
-            Collections.singletonList(new BranchSpec("*/master")), 
+            Collections.singletonList(new BranchSpec("*/main")), 
             false, 
             Collections.<SubmoduleConfig>emptyList(), 
             null, 

--- a/src/test/groovy/org/boozallen/plugins/jte/config/TemplateLibrarySourceSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/config/TemplateLibrarySourceSpec.groovy
@@ -56,7 +56,7 @@ class TemplateLibrarySourceSpec extends Specification{
 
         GitSCM scm = new GitSCM(
             GitSCM.createRepoList(repo.toString(), null),
-            Collections.singletonList(new BranchSpec("*/master")),
+            Collections.singletonList(new BranchSpec("*/main")),
             false,
             Collections.<SubmoduleConfig>emptyList(),
             null,

--- a/src/test/groovy/org/boozallen/plugins/jte/utils/ScmSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/utils/ScmSpec.groovy
@@ -115,7 +115,7 @@ class ScmSpec extends Specification {
         // create Governance Tier
         scm = new GitSCM(
                 GitSCM.createRepoList(sampleRepo.toString(), null),
-                Collections.singletonList(new BranchSpec("*/master")),
+                Collections.singletonList(new BranchSpec("*/main")),
                 false,
                 Collections.<SubmoduleConfig>emptyList(),
                 null,


### PR DESCRIPTION
# PR Details

New repositories use `main` as default branch name.

## Description

I ran into issues going through the SDP learning lab because I assumed it was safe to keep my branch defined as `master`. Once I inspected my repository I noticed that GitHub now uses `main` as the default branch name for new repositories.

More info can be found here:
https://github.com/github/renaming

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I did not test this change, but I can confirm that new repositories use `main` by default and this stump new users who are following the SDP learning lab.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [ ] If necessary, I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
